### PR TITLE
Fix unbalanced closing bracket bug

### DIFF
--- a/src/balance_parenthesis.py
+++ b/src/balance_parenthesis.py
@@ -29,6 +29,8 @@ def is_balanced(text):
         if char in OPENING:
             stack.append(char)
         else:
+            if not stack:
+                return False
             pair = stack.pop()
             if not are_matching(pair, char):
                 return False

--- a/tests/test__balance_parenthesis.py
+++ b/tests/test__balance_parenthesis.py
@@ -26,6 +26,10 @@ CASES = [
         "text": "((()",
         "answer": False,
     },
+    {
+        "text": ")(",
+        "answer": False,
+    },
 ]
 
 


### PR DESCRIPTION
## Summary
- guard against stack underflow in `is_balanced`
- add test for unmatched closing bracket

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686de28c49388326951f6338a9e3d724