### PR TITLE
Fix currency arbitrage sequence rotation

### DIFF
--- a/src/currency_arbitrage.py
+++ b/src/currency_arbitrage.py
@@ -10,7 +10,9 @@ def all_permutations(rates):
 def execute(sequence, rates):
     amount = 1
     current_symbol = sequence[0]
-    sequence = *sequence[1:], sequence[0]
+    # Rotate the sequence so that we continue converting using
+    # the next currency in line and finish back at the start.
+    sequence = (*sequence[1:], sequence[0])
     for next_symbol in sequence:
         rate = rates[current_symbol][next_symbol]
         amount *= rate


### PR DESCRIPTION
## Summary
- correct tuple expression for rotating the sequence in `currency_arbitrage.execute`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de73f13688326a66bf40ce59fad97