### PR TITLE
Fix run_length_encoding filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,8 +441,8 @@ encoded have no digits and consists solely of alphabetic characters. You can
 assume the string to be decoded is valid.
 
 Solution:
-- [tests](tests/test__run_lenght_encoding.py)
-- [implementation](src/run_lenght_encoding.py)
+- [tests](tests/test__run_length_encoding.py)
+- [implementation](src/run_length_encoding.py)
 
 
 ## Balance Parenthesis

--- a/src/run_length_encoding.py
+++ b/src/run_length_encoding.py
@@ -1,5 +1,5 @@
 def encode(original):
-    """RUN-LENGHT ENCODING
+    """RUN-LENGTH ENCODING
 
     This problem was asked by Amazon.
     Difficulty: Easy

--- a/tests/test__run_length_encoding.py
+++ b/tests/test__run_length_encoding.py
@@ -1,9 +1,9 @@
 from pytest import fixture
 
-from src.run_lenght_encoding import encode
+from src.run_length_encoding import encode
 
 """
-RUN-LENGHT ENCODING
+RUN-LENGTH ENCODING
 
 This problem was asked by Amazon.
 Difficulty: Easy


### PR DESCRIPTION
## Summary
- rename `src/run_lenght_encoding.py` to `src/run_length_encoding.py`
- rename and update corresponding test file
- fix imports and README references

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de71fb4808326aed38b45ae982b35