### PR TITLE
Fix Difficulty spelling in documentation

### DIFF
--- a/src/autocomplete_system.py
+++ b/src/autocomplete_system.py
@@ -40,7 +40,7 @@ def autocomplete_system(symbols, query):
     AUTOCOMPLETE SYSTEM
 
     This problem was asked by Twitter.
-    Dificulty: Medium
+    Difficulty: Medium
 
     Implement an autocomplete system. That is, given a query string s and a set of all
     possible query strings, return all strings in the set that have s as aprefix. For

--- a/src/memory_efficient_random.py
+++ b/src/memory_efficient_random.py
@@ -6,7 +6,7 @@ def memory_efficient_random(elements):
     """MEMORY EFFICIENT RANDOM
 
     This problem was asked by Facebook.
-    Dificulty: Medium
+    Difficulty: Medium
 
     Given a stream of elements too large to store in memory, pick a random
     element from the stream with uniform probability.

--- a/src/monte_carlo_pi.py
+++ b/src/monte_carlo_pi.py
@@ -22,7 +22,7 @@ def monte_carlo_pi(precision=4):
     """MONTE CARLO PI
 
     This problem was asked by Google.
-    Dificulty: Medium
+    Difficulty: Medium
 
     The area of a circle is defined as πr^2. Estimate π to 3 decimal places using a
     Monte Carlo method.

--- a/src/staircase_silly_walks.py
+++ b/src/staircase_silly_walks.py
@@ -12,7 +12,7 @@ def get_climb_combinations(steps, leaps):
     STAIRCASE SILLY WALKS
 
     This problem was asked by Amazon.
-    Dificulty: Hard
+    Difficulty: Hard
 
     There exists a staircase with N steps, and you can climb up either 1 or 2 steps at a
     time. Given N, write a function that returns the number of unique ways you can climb

--- a/tests/test__autocomplete_system.py
+++ b/tests/test__autocomplete_system.py
@@ -8,7 +8,7 @@ from src.autocomplete_system import autocomplete_system, Trie
 AUTOCOMPLETE SYSTEM
 
 This problem was asked by Twitter.
-Dificulty: Medium
+Difficulty: Medium
 
 Implement an autocomplete system. That is, given a query string s and a set of all
 possible query strings, return all strings in the set that have s as aprefix. For

--- a/tests/test__justify.py
+++ b/tests/test__justify.py
@@ -6,7 +6,7 @@ from src.justify import justify, total_length, justify_line
 JUSTIFY
 
 This problem was asked by Palantir.
-Dificulty: Medium
+Difficulty: Medium
 
 Write an algorithm to justify text. Given a sequence of words and an integer line
 length k, return a list of strings which represents each line,

--- a/tests/test__memory_efficient_random.py
+++ b/tests/test__memory_efficient_random.py
@@ -8,7 +8,7 @@ from src.memory_efficient_random import memory_efficient_random
 MEMORY EFFICIENT RANDOM
 
 This problem was asked by Facebook.
-Dificulty: Medium
+Difficulty: Medium
 
 Given a stream of elements too large to store in memory, pick a random elementfrom
 the stream with uniform probability.

--- a/tests/test__monte_carlo_pi.py
+++ b/tests/test__monte_carlo_pi.py
@@ -9,7 +9,7 @@ from src.monte_carlo_pi import monte_carlo_pi, primes
 MONTE CARLO PI
 
 This problem was asked by Google.
-Dificulty: Medium
+Difficulty: Medium
 
 The area of a circle is defined as πr^2. Estimate π to 3 decimal places using a Monte
 Carlo method.

--- a/tests/test__simple_job_scheduler.py
+++ b/tests/test__simple_job_scheduler.py
@@ -8,7 +8,7 @@ from src.simple_job_scheduler import simple_job_scheduler, SCHEDULER
 SIMPLE JOB SCHEDULER
 
 This problem was asked by Apple.
-Dificulty: Medium
+Difficulty: Medium
 
 Implement a job scheduler which takes in a function f and an integer n, and calls f
 after n milliseconds.


### PR DESCRIPTION
## Summary
- fix spelling error "Dificulty" -> "Difficulty" in docstrings and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de74260e48326a1dcc8e93f66dd56