### PR TITLE
Add tree_again None cases

### DIFF
--- a/tests/test__tree_again.py
+++ b/tests/test__tree_again.py
@@ -47,3 +47,13 @@ def test__serialize__examples():
     assert tree_again.left.left.val == 'left.left'
 
     assert tree_again != pickled
+
+
+def test__serialize__none():
+    result = serialize(None)
+    assert result == "None"
+
+
+def test__deserialize__none():
+    result = deserialize("None")
+    assert result is None


### PR DESCRIPTION
## Summary
- extend test suite for tree_again serialization/deserialization
- new tests cover calling `serialize(None)` and `deserialize("None")`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686de7482fcc8326973715023f1465a1