### PR TITLE
Add bootstrap.sh for environment setup

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# bootstrap.sh - Setup development environment for the algorithms project
+
+set -euo pipefail
+
+# Detect OS
+OS="$(uname)"
+
+function info() { echo -e "\033[1;34m[INFO]\033[0m $*"; }
+function warn() { echo -e "\033[1;33m[WARN]\033[0m $*"; }
+
+function install_uv() {
+    if command -v uv >/dev/null 2>&1; then
+        info "uv already installed"
+    else
+        info "Installing uv (fast Python package manager)"
+        if command -v curl >/dev/null 2>&1; then
+            curl -Ls https://astral.sh/uv/install.sh | bash
+            export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+        else
+            warn "curl not found. Please install curl and re-run the script."
+            exit 1
+        fi
+    fi
+}
+
+function install_python_linux() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        info "Installing Python"
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-venv python3-pip
+    fi
+}
+
+function install_python_mac() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        if command -v brew >/dev/null 2>&1; then
+            info "Installing Python via Homebrew"
+            brew install python
+        else
+            warn "Homebrew not found. Please install Homebrew or Python manually."
+            exit 1
+        fi
+    fi
+}
+
+case "$OS" in
+    Linux*)
+        install_python_linux
+        ;;
+    Darwin*)
+        install_python_mac
+        ;;
+    *)
+        echo "Unsupported OS: $OS" >&2
+        exit 1
+        ;;
+esac
+
+install_uv
+
+info "Synchronizing dependencies with uv"
+uv sync
+
+info "Setup complete. Activate the environment with:\n  source .venv/bin/activate"


### PR DESCRIPTION
## Summary
- add `bootstrap.sh` script to automate installation of Python and `uv`
- automatically sync dependencies using `uv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dea37790c83269d8846fc1036715f