### PR TITLE
Improve bootstrap.sh script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,12 +11,16 @@ function info() { echo -e "\033[1;34m[INFO]\033[0m $*"; }
 function warn() { echo -e "\033[1;33m[WARN]\033[0m $*"; }
 
 function install_uv() {
+    # Ensure potential uv installation paths are in PATH for this script execution
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
     if command -v uv >/dev/null 2>&1; then
         info "uv already installed"
     else
         info "Installing uv (fast Python package manager)"
         if command -v curl >/dev/null 2>&1; then
             curl -Ls https://astral.sh/uv/install.sh | bash
+            # Re-export PATH to ensure it's available for subsequent commands if uv was just installed
             export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
         else
             warn "curl not found. Please install curl and re-run the script."
@@ -31,12 +35,26 @@ function install_just() {
     else
         info "Installing just (command runner)"
         if command -v cargo >/dev/null 2>&1; then
-            cargo install just
-        elif command -v brew >/dev/null 2>&1; then
-            brew install just
+            info "Attempting to install just using cargo"
+            if ! cargo install just; then
+                warn "Failed to install just using cargo. Please check cargo output."
+                exit 1
+            fi
+        elif command -v brew >/dev/null 2>&1; then # Typically macOS
+            info "Attempting to install just using brew"
+            if ! brew install just; then
+                warn "Failed to install just using brew. Please check brew output."
+                exit 1
+            fi
+        elif [[ "$OS" == "Linux"* ]] && command -v apt-get >/dev/null 2>&1; then
+            info "Attempting to install just using apt"
+            if ! (sudo apt-get update && sudo apt-get install -y just); then
+                warn "Failed to install just using apt. Please check apt output."
+                exit 1
+            fi
         else
-            warn "Neither cargo nor brew found. Please install 'just' manually."
-            return
+            warn "Could not find cargo, brew, or apt (for Linux) to install just. Please install 'just' manually."
+            exit 1
         fi
     fi
 }


### PR DESCRIPTION
Enhanced the bootstrap.sh script with the following improvements:

- `install_just`: Added support for installing `just` via `apt` on Linux if `cargo` is not available.
- `install_just`: Strengthened error handling to exit the script if `just` installation fails via any method.
- `install_uv`: Improved `uv` path detection by adding common installation directories to `PATH` before checking for `uv`'s existence.